### PR TITLE
Floor fractional screen dimensions

### DIFF
--- a/electron/handlers/ipcHandler.js
+++ b/electron/handlers/ipcHandler.js
@@ -135,9 +135,9 @@ function ipcHandler() {
 
       //calcula el tamaño completo de la pantalla  //TODO: Optimizar para siempre tener actualizado dado el monitor. Debe ser cambiado si el monitor cambia o su scale factor
       const screenDetails = screen.getPrimaryDisplay();
-      const screenWidth = screenDetails.size.width * screenDetails.scaleFactor;
+      const screenWidth = Math.floor(screenDetails.size.width * screenDetails.scaleFactor);
       const screenHeight =
-        screenDetails.size.height * screenDetails.scaleFactor;
+        Math.floor(screenDetails.size.height * screenDetails.scaleFactor);
 
       //Tomar la imagen de  la pantalla
       const sources = await desktopCapturer.getSources({


### PR DESCRIPTION
Should fix #1 

I've experienced the linked issue when using fractional scaling on ubuntu and win11, and have determined it to be due to a conversion error thrown when decimal numbers are supplied as thumbnail size parameters to `desktopCapturer.getSources`

A quick fix is to just floor the fractional pixels. I've tested this locally on my win11 laptop. 